### PR TITLE
added includeconfig for inhouse config

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -54,6 +54,8 @@ params {
     config_profile_url         = null
     config_profile_name        = null
 
+    local_config_path          = null
+
     // Max resource options
     // Defaults only, expecting to be overwritten
     max_memory                 = '128.GB'
@@ -73,6 +75,18 @@ try {
     includeConfig "${params.custom_config_base}/nfcore_custom.config"
 } catch (Exception e) {
     System.err.println("WARNING: Could not load nf-core/config profiles: ${params.custom_config_base}/nfcore_custom.config")
+}
+
+// Load nf-core/raredisease custom config
+try {
+    includeConfig "${params.custom_config_base}/pipeline/raredisease.config"
+} catch (Exception e) {
+    System.err.println("WARNING: Could not load nf-core/config/raredisease profiles: ${params.custom_config_base}/pipeline/raredisease.config")
+}
+
+// Load in-house config
+if (params.local_config_path) {
+    includeConfig "${params.local_config_path}"
 }
 
 // Load igenomes.config if required, else load custom genomes.config

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -197,6 +197,11 @@
                     "description": "Institutional config URL link.",
                     "hidden": true,
                     "fa_icon": "fas fa-users-cog"
+                },
+                "local_config_path": {
+                    "type": "string",
+                    "description": "Path to local config",
+                    "fa_icon": "fas fa-users-cog"
                 }
             }
         },


### PR DESCRIPTION
<!--
# nf-core/raredisease pull request

Many thanks for contributing to nf-core/raredisease!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist
This PR:
1) enables the usage of local/in-house configurations without needing to pass them in via CLI. This includes e.g. `--igenomes_ignore --local_genomes /path/to/dir` all in one place and the addition of `--genome GRCh28` if desired.

The justification for new param `--local_config_path` instead of using the native `-c` nextflow option for passing in a config is because `-c path/to/config` is evaluated separately from existing params loaded in through `includeConfig` directive and then it's merged. This causes conflicts in nextflow compiler recognizing certain parameters I included in the `path/to/config`

2) usage of pipeline specific institutional profiles (this can be found in the `nextflow.config`) where the pipeline specific config will be inherited by the basic institutional config
- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/raredisease _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
