### PR TITLE
Add Gatk4 GermlineCNVCaller module

### DIFF
--- a/modules/local/gatk4/germlinecnvcaller/main.nf
+++ b/modules/local/gatk4/germlinecnvcaller/main.nf
@@ -1,0 +1,52 @@
+process GATK4_GERMLINECNVCALLER {
+    tag "$meta.id"
+    label 'process_medium'
+
+    if(params.enable_conda){
+        error "Conda environments cannot be used for GATK4/DetermineGermlineContigPloidy at the moment. Please use docker or singularity containers."
+    }
+    container "broadinstitute/gatk:4.3.0.0"
+
+    input:
+    tuple val(meta), path(tsv)
+    path intervals
+    path model
+    path ploidy
+
+    output:
+    tuple val(meta), path("*.tar.gz"), emit: tar_gz
+    path  "versions.yml"          , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def intervals_command = intervals ? "--intervals $intervals" : ""
+    def model_command = model ? "--model $model" : ""
+    def input_list = tsv.collect{"--input $it"}.join(' ')
+
+    def avail_mem = 3
+    if (!task.memory) {
+        log.info '[GATK GermlineCNVCaller] Available memory not known - defaulting to 3GB. Specify process memory requirements to change this.'
+    } else {
+        avail_mem = task.memory.giga
+    }
+    """
+    gatk --java-options "-Xmx${avail_mem}g" GermlineCNVCaller \\
+        $input_list \\
+        --contig-ploidy-calls ${prefix}-calls \\
+        --output cnv_calls/ \\
+        --output-prefix $prefix \\
+        $args \\
+        $intervals_command \\
+        $model_command
+    tar -czvf cnv_calls.tar.gz cnv_calls
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        gatk4: \$(echo \$(gatk --version 2>&1) | sed 's/^.*(GATK) v//; s/ .*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/local/gatk4/germlinecnvcaller/meta.yml
+++ b/modules/local/gatk4/germlinecnvcaller/meta.yml
@@ -1,0 +1,52 @@
+name: "gatk4_germlinecnvcaller"
+description: Calls copy-number variants in germline samples given their counts and the output of DetermineGermlineContigPloidy.
+keywords:
+  - gatk
+  - gatk4_germlinecnvcaller
+tools:
+  - "gatk4":
+      description:
+        Developed in the Data Sciences Platform at the Broad Institute, the toolkit offers a wide variety of tools
+        with a primary focus on variant discovery and genotyping. Its powerful processing engine
+        and high-performance computing features make it capable of taking on projects of any size.
+      homepage: https://gatk.broadinstitute.org/hc/en-us
+      documentation: https://gatk.broadinstitute.org/hc/en-us/categories/360002369672s
+      doi: "10.1158/1538-7445.AM2017-3590"
+      licence: ["Apache-2.0"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - tsv:
+      type: file
+      description: TSV file
+      pattern: "*.tsv"
+  - model:
+      type: directory
+      description: model directory
+  - tar:
+      type: file
+      description: TAR file
+      pattern: "*.tar"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - tar:
+      type: file
+      description: TAR file
+      pattern: "*.tar"
+
+authors:
+  - "@ryanjameskennedy"
+  - "@ViktorHy"


### PR DESCRIPTION
I have been trying to add this module (gatk4 GermlineCNVCaller) to nf-core/modules for quite some time, but seem to be stuck on the testing part. I have created an [issue on broadinstitute's github page](https://github.com/broadinstitute/gatk/issues/8097) outlining the problem and containing the test files and how to run the test (NOTE: Docker is required to test it). Any help is appreciated! I will create a draft PR to nf-core/modules asap (so you can test it yourself using nf-core's testing software if you wish.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/raredisease _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [] Make sure your code lints (`nf-core lint`).
- [] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR> -stub`).
- [] Usage Documentation in `docs/usage.md` is updated.
- [] Output Documentation in `docs/output.md` is updated.
- [] `CHANGELOG.md` is updated.
- [] `README.md` is updated (including new tool citations and authors/contributors).
