### PR TITLE
update smncopynumbercaller

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -292,7 +292,7 @@
                     },
                     "smncopynumbercaller": {
                         "branch": "master",
-                        "git_sha": "e70433b04bef836b22bbed5a1e6e4e95aeec09fe",
+                        "git_sha": "c5620578276a1927f5b4afbc2b4266c9cf7b43ca",
                         "installed_by": ["modules"]
                     },
                     "stranger": {

--- a/modules/nf-core/smncopynumbercaller/main.nf
+++ b/modules/nf-core/smncopynumbercaller/main.nf
@@ -19,18 +19,19 @@ process SMNCOPYNUMBERCALLER {
     task.ext.when == null || task.ext.when
 
     script:
-    manifest_text = bam.join("\n")
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def VERSION = "1.1.2" // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     """
-    echo "$manifest_text" >manifest.txt
+    echo $bam | tr ' ' '
+    ' > manifest.txt
     smn_caller.py \\
         $args \\
         --manifest manifest.txt \\
         --prefix $prefix \\
         --outDir "out" \\
         --threads $task.cpus
+
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         SMNCopyNumberCaller: $VERSION
@@ -44,6 +45,7 @@ process SMNCOPYNUMBERCALLER {
     mkdir out
     touch out/${prefix}.tsv
     touch out/${prefix}.json
+
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         SMNCopyNumberCaller: $VERSION


### PR DESCRIPTION
Update SmnCopyNumberCaller to implement the latest changes by doing:
`nf-core modules update smncopynumbercaller`

The new updates make the pipeline complete successfully:
`nextflow run . -profile test,singularity --outdir results`

![image](https://user-images.githubusercontent.com/57712924/221556895-211a42b8-81dd-4068-9914-b6f6dd9103ef.png)

Output as expected for smncopynumbercaller:
<img width="966" alt="image" src="https://user-images.githubusercontent.com/57712924/221557249-05d3ab4f-46fc-4467-9661-d5303e0a3e3a.png">

Note that the lack of correct output in the justhusky.tsv file is because of the lack of reads on chr 5 and 6 in the test data.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/raredisease _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR> -stub`).
- [x] Ensure the test suite passes (`nextflow run . -profile test_one_sample,docker --outdir <OUTDIR> -stub`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
