### PR TITLE
Correct GATK4 container spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- Invalid GATK4 container which caused incorrect singularity downloads with nf-core download [nf-core/modules #3668](https://github.com/nf-core/modules/issues/3668)
+
 ## v1.1.1 - Abu (Patch) [2023-07-26]
 
 ### `Fixed`

--- a/modules.json
+++ b/modules.json
@@ -117,7 +117,7 @@
                     },
                     "gatk4/determinegermlinecontigploidy": {
                         "branch": "master",
-                        "git_sha": "d25bf48327e86a7f737047a57ec264b90e22ce3d",
+                        "git_sha": "c6257c167fb88d18f3c2797e1af331d28f7b8ae7",
                         "installed_by": ["modules"]
                     },
                     "gatk4/filtermutectcalls": {
@@ -152,7 +152,7 @@
                     },
                     "gatk4/postprocessgermlinecnvcalls": {
                         "branch": "master",
-                        "git_sha": "39ca55cc30514169f8420162bafe4ecf673f4b9a",
+                        "git_sha": "c6257c167fb88d18f3c2797e1af331d28f7b8ae7",
                         "installed_by": ["modules"]
                     },
                     "gatk4/preprocessintervals": {

--- a/modules/nf-core/gatk4/determinegermlinecontigploidy/main.nf
+++ b/modules/nf-core/gatk4/determinegermlinecontigploidy/main.nf
@@ -4,7 +4,7 @@ process GATK4_DETERMINEGERMLINECONTIGPLOIDY {
     label 'process_single'
 
     //Conda is not supported at the moment: https://github.com/broadinstitute/gatk/issues/7811
-    container "quay.io/nf-core/gatk:4.4.0.0" //Biocontainers is missing a package
+    container "nf-core/gatk:4.4.0.0" //Biocontainers is missing a package
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/nf-core/gatk4/postprocessgermlinecnvcalls/main.nf
+++ b/modules/nf-core/gatk4/postprocessgermlinecnvcalls/main.nf
@@ -3,7 +3,7 @@ process GATK4_POSTPROCESSGERMLINECNVCALLS {
     label 'process_single'
 
     //Conda is not supported at the moment: https://github.com/broadinstitute/gatk/issues/7811
-    container "quay.io/nf-core/gatk:4.4.0.0" //Biocontainers is missing a package
+    container "nf-core/gatk:4.4.0.0" //Biocontainers is missing a package
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {


### PR DESCRIPTION
Updates nf-core/gatk4 container and removes prefix 'quay.io' that was breaking nf-core downloads.

Fixes https://github.com/nf-core/modules/issues/3668 for this repo specifically.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/raredisease _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test_one_sample,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
