### PR TITLE
Make cram prefix same as the default markduplicates prefix 

### DIFF
--- a/conf/modules/align.config
+++ b/conf/modules/align.config
@@ -19,8 +19,9 @@ process{
     }
 
     withName: '.*ALIGN:SAMTOOLS_VIEW' {
-        ext.args = { '--output-fmt cram --write-index' }
-        ext.when = params.save_mapped_as_cram
+        ext.args   = { '--output-fmt cram --write-index' }
+        ext.prefix = { "${meta.id}_sorted_md" }
+        ext.when   = params.save_mapped_as_cram
         publishDir = [
             path: { "${params.outdir}/alignment" },
             mode: params.publish_dir_mode,


### PR DESCRIPTION
<!--
# nf-core/raredisease pull request

Many thanks for contributing to nf-core/raredisease!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

This PR updates the prefix of the cram output so that it is the same as the default (markduplicates) prefix. 

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/raredisease _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test_one_sample,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
