### PR TITLE
Fix two instances of wrong process name passed to `ch_versions.mix()` when running in sentieon mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced the logic where we added an arbitrary substring to keep file names unique after alignment which we then removed using a split operator, with a simple copy operation. [#425](https://github.com/nf-core/raredisease/pull/425/files)
 - Preventing a crash of rhocall annotate in the case of running four individuals whereof two are affected.
 - Fixed memory qualifier in gatk4 germlinecnvcaller and postprocessgermlinecnvcalls
+- Fixed wrong process names when outputting versions in `ALIGN_SENTIEON` and `CALL_SNV`.
 
 ### `Updated`
 

--- a/subworkflows/local/alignment/align_MT.nf
+++ b/subworkflows/local/alignment/align_MT.nf
@@ -32,7 +32,7 @@ workflow ALIGN_MT {
         } else if (params.aligner.equals("sentieon")) {
             SENTIEON_BWAMEM_MT ( ch_fastq, ch_bwaindex, ch_fasta, ch_fai )
             ch_sentieon_bam = SENTIEON_BWAMEM_MT.out.bam_and_bai.map{ meta, bam, bai -> [meta, bam] }
-            ch_versions     = ch_versions.mix(BWAMEM2_MEM_MT.out.versions.first())
+            ch_versions     = ch_versions.mix(SENTIEON_BWAMEM_MT.out.versions.first())
         }
 
         Channel.empty()

--- a/subworkflows/local/call_snv.nf
+++ b/subworkflows/local/call_snv.nf
@@ -61,7 +61,7 @@ workflow CALL_SNV {
             )
             ch_sentieon_vcf = CALL_SNV_SENTIEON.out.vcf
             ch_sentieon_tbi = CALL_SNV_SENTIEON.out.tabix
-            ch_versions    = ch_versions.mix(CALL_SNV_DEEPVARIANT.out.versions)
+            ch_versions    = ch_versions.mix(CALL_SNV_SENTIEON.out.versions)
         }
 
         ch_vcf       = Channel.empty().mix(ch_deepvar_vcf, ch_sentieon_vcf)


### PR DESCRIPTION
<!--
# nf-core/raredisease pull request

Many thanks for contributing to nf-core/raredisease!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
-->

This small update fixes two similar bugs where the wrong process name is passed in a call to `ch_versions.mix()` when run in sentieon mode. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/raredisease _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test_one_sample,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
