### PR TITLE
updating mitochondria filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `add_most_severe_consequence` and `add_most_severe_pli` to fix spelling and language server warnings [#689](https://github.com/nf-core/raredisease/pull/689)
 - Refactored code to address issues highlighted by language server [#688](https://github.com/nf-core/raredisease/pull/688)
 - Changed for loop to each in create_pedigree_file [#683](https://github.com/nf-core/raredisease/pull/683)
+- Changed default to remove mitochondrial variants with FILTER status not equal to PASS [#696](https://github.com/nf-core/raredisease/pull/696)
 
 ### `Fixed`
 
 - Errors due to channel name and structure inconsistencies in the sentieon SNV calling subworkflow[#688](https://github.com/nf-core/raredisease/pull/688)
+- Use '--mitochondria-mode' by default when running Gatk4 FilterMutectCalls on mitochondrial variants[#696](https://github.com/nf-core/raredisease/pull/696)
 
 ### Parameters
 

--- a/conf/modules/call_snv_MT.config
+++ b/conf/modules/call_snv_MT.config
@@ -22,6 +22,7 @@ process {
     }
 
     withName: '.*CALL_SNV_MT:GATK4_FILTERMUTECTCALLS_MT' {
+        ext.args = '--mitochondria-mode'
         ext.prefix = { "${meta.id}_filtered" }
     }
 
@@ -46,6 +47,7 @@ process {
     }
 
     withName: '.*CALL_SNV_MT_SHIFT:GATK4_FILTERMUTECTCALLS_MT' {
+        ext.args = '--mitochondria-mode'
         ext.prefix = { "${meta.id}_filtered_shifted" }
     }
 

--- a/conf/modules/postprocess_MT_calls.config
+++ b/conf/modules/postprocess_MT_calls.config
@@ -45,7 +45,7 @@ process {
     }
 
     withName: '.*POSTPROCESS_MT_CALLS:BCFTOOLS_ANNOTATE' {
-        ext.args = '-c CHROM,FROM,TO,FOUND_IN --output-type z --apply-filters .,PASS'
+        ext.args = '-c CHROM,FROM,TO,FOUND_IN --output-type z --include \'FILTER="PASS"\''
         ext.prefix = { "${meta.id}_mitochondria" }
         publishDir = [
             path: { "${params.outdir}/call_snv/mitochondria" },

--- a/conf/modules/postprocess_MT_calls.config
+++ b/conf/modules/postprocess_MT_calls.config
@@ -45,7 +45,7 @@ process {
     }
 
     withName: '.*POSTPROCESS_MT_CALLS:BCFTOOLS_ANNOTATE' {
-        ext.args = '-c CHROM,FROM,TO,FOUND_IN --output-type z --include \'FILTER="PASS"\''
+        ext.args = '-c CHROM,FROM,TO,FOUND_IN --output-type z --apply-filters .,PASS'
         ext.prefix = { "${meta.id}_mitochondria" }
         publishDir = [
             path: { "${params.outdir}/call_snv/mitochondria" },

--- a/conf/modules/postprocess_MT_calls.config
+++ b/conf/modules/postprocess_MT_calls.config
@@ -45,7 +45,7 @@ process {
     }
 
     withName: '.*POSTPROCESS_MT_CALLS:BCFTOOLS_ANNOTATE' {
-        ext.args = "-c CHROM,FROM,TO,FOUND_IN --output-type z"
+        ext.args = '-c CHROM,FROM,TO,FOUND_IN --output-type z --include \'FILTER="PASS"\''
         ext.prefix = { "${meta.id}_mitochondria" }
         publishDir = [
             path: { "${params.outdir}/call_snv/mitochondria" },

--- a/subworkflows/local/generate_cytosure_files.nf
+++ b/subworkflows/local/generate_cytosure_files.nf
@@ -71,18 +71,11 @@ workflow GENERATE_CYTOSURE_FILES {
 
         Channel.empty()
             .mix(ch_for_mix.split, ch_for_mix.reheader)
-            .toSortedList { a, b -> a[0].id <=> b[0].id }
-            .flatMap()
             .set { ch_vcf2cytosure_in }
-
-        TIDDIT_COV_VCF2CYTOSURE.out.cov
-            .toSortedList { a, b -> a[0].id <=> b[0].id }
-            .flatMap()
-            .set { ch_cov2cytosure_in }
 
         VCF2CYTOSURE (
             ch_vcf2cytosure_in,
-            ch_cov2cytosure_in,
+            TIDDIT_COV_VCF2CYTOSURE.out.cov,
             [[:], []], [[:], []],
             ch_blacklist
         )

--- a/subworkflows/local/generate_cytosure_files.nf
+++ b/subworkflows/local/generate_cytosure_files.nf
@@ -71,11 +71,18 @@ workflow GENERATE_CYTOSURE_FILES {
 
         Channel.empty()
             .mix(ch_for_mix.split, ch_for_mix.reheader)
+            .toSortedList { a, b -> a[0].id <=> b[0].id }
+            .flatMap()
             .set { ch_vcf2cytosure_in }
+
+        TIDDIT_COV_VCF2CYTOSURE.out.cov
+            .toSortedList { a, b -> a[0].id <=> b[0].id }
+            .flatMap()
+            .set { ch_cov2cytosure_in }
 
         VCF2CYTOSURE (
             ch_vcf2cytosure_in,
-            TIDDIT_COV_VCF2CYTOSURE.out.cov,
+            ch_cov2cytosure_in,
             [[:], []], [[:], []],
             ch_blacklist
         )


### PR DESCRIPTION
<!--
# nf-core/raredisease pull request

Many thanks for contributing to nf-core/raredisease!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
-->

The pipeline didn't run the FilterMutectCalls on the mitochondria with the option `--mitochondria-mode` leading to a the variants getting filters set when they shouldn't. These are the filters affected "clustered_events", "multiallelic", "slippage", "haplotype", "fragement", "germline". This PR also removes the remaining mitochondrial variants that gets filtered.  


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/raredisease _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test_one_sample,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
