### PR TITLE
Remove duplicate input causing test profile to fail

### DIFF
--- a/subworkflows/local/annotate_mt_snvs.nf
+++ b/subworkflows/local/annotate_mt_snvs.nf
@@ -26,7 +26,6 @@ workflow ANNOTATE_MT_SNVS {
         val_vep_genome         // string:  [mandatory] GRCh37 or GRCh38
         val_vep_cache_version  // string:  [mandatory] 107
         ch_vep_cache           // channel: [mandatory] [ path(cache) ]
-        ch_vep_cache           // channel: [mandatory] [ path(cache) ]
         ch_vep_extra_files     // channel: [mandatory] [ path(files) ]
 
     main:


### PR DESCRIPTION
Hi,
I tried running this:
```
nextflow run nf-core/raredisease -revision 2.5.0 -profile test --outdir /home/azureuser/debug/
```
I got:
```
Workflow `NFCORE_RAREDISEASE:RAREDISEASE:ANNOTATE_MT_SNVS` declares 14 input channels but 13 were given
```

```
ANNOTATE_MT_SNVS (
    CALL_SNV.out.mt_vcf,
    CALL_SNV.out.mt_tabix,
    ch_cadd_header,
    ch_cadd_resources,
    ch_genome_fasta,
    ch_vcfanno_extra,
    ch_vcfanno_lua,
    ch_vcfanno_resources,
    ch_vcfanno_toml,
    params.genome,
    params.vep_cache_version,
    ch_vep_cache,
    ch_vep_extra_files
).set { ch_mt_annotate }
```

But the file I have looked at has `ch_vep_cache` twice.

I haven't setup the local dev tools yet but I will when I get a moment.

Chat here:
https://nfcore.slack.com/archives/C025UH66DA8/p1749004714662999

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/raredisease _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test_one_sample,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
