### PR TITLE
Add interval parameter to RetroSeq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+- Interval parameter in the default retroseq call [#717](https://github.com/nf-core/raredisease/pull/717)
+
 ### `Changed`
 
 ### `Fixed`

--- a/conf/modules/call_mobile_elements.config
+++ b/conf/modules/call_mobile_elements.config
@@ -27,7 +27,7 @@ process {
     }
 
     withName: '.*CALL_MOBILE_ELEMENTS:RETROSEQ_CALL' {
-        ext.args = { '--soft' }
+        ext.args = { "--soft --region ${meta.interval}" }
         ext.prefix = { "${meta.id}_${meta.interval}_retroseq_call" }
     }
 


### PR DESCRIPTION
This PR implements the suggestions from tk2/RetroSeq#24, addressing the following error in the call_mobile_elements module:
`ERROR: Invalid parameters passed to getCandidateBreakPointsDir`

<!--
# nf-core/raredisease pull request

Many thanks for contributing to nf-core/raredisease!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/raredisease _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test_singleton,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
