### PR TITLE
skip HGNC ID filtering for mt clinical set

### DIFF
--- a/subworkflows/local/generate_clinical_set.nf
+++ b/subworkflows/local/generate_clinical_set.nf
@@ -13,26 +13,26 @@ workflow GENERATE_CLINICAL_SET {
         val_ismt    // value: if mitochondria, set to true
 
     main:
+        ch_clinical = Channel.empty()
         ch_versions = Channel.empty()
 
-        ENSEMBLVEP_FILTERVEP(
-            ch_vcf,
-            ch_hgnc_ids
-        )
-        .output
-        .set { ch_filtervep_out }
-
         if (val_ismt) {
-            BCFTOOLS_FILTER (ch_filtervep_out.map { meta, vcf -> return [meta, vcf, []]})
+            BCFTOOLS_FILTER (ch_vcf.map { meta, vcf -> return [meta, vcf, []]})
             ch_clinical = BCFTOOLS_FILTER.out.vcf
             ch_versions = ch_versions.mix( BCFTOOLS_FILTER.out.versions )
         } else {
+            ENSEMBLVEP_FILTERVEP(
+                ch_vcf,
+                ch_hgnc_ids
+            )
+            .output
+            .set { ch_filtervep_out }
+
             TABIX_BGZIP( ch_filtervep_out )
             ch_clinical = TABIX_BGZIP.out.output
+            ch_versions = ch_versions.mix( ENSEMBLVEP_FILTERVEP.out.versions )
             ch_versions = ch_versions.mix( TABIX_BGZIP.out.versions )
         }
-
-        ch_versions = ch_versions.mix( ENSEMBLVEP_FILTERVEP.out.versions )
 
     emit:
         vcf      = ch_clinical // channel: [ val(meta), path(vcf) ]


### PR DESCRIPTION
Previously, all clinical VCFs were filtered with VEP to keep only variants in the specified HGNC genes. Now, for mitochondrial datasets, this VEP-based filtering is skipped, and the variants are only processed with BCFTOOLS_FILTER. This means mitochondrial outputs will now include all variants, not just those in the HGNC list. The heteroplasmy filter is still the same.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/raredisease _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test_singleton,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
