### PR TITLE
Fix issue 719: Allow bait padding zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed conda declaration in the add_varcallername_to_bed module [#733](https://github.com/nf-core/raredisease/pull/733)
 - Fixed CADD annotation to support chr prefix [#745](https://github.com/nf-core/raredisease/pull/745)
 - Fixed mismatch between VCF and ROH calls when analysing multiple samples [#755](https://github.com/nf-core/raredisease/pull/755)
+- Fixed pipeline to run variant calling even with bait_padding set to 0 [#757](https://github.com/nf-core/raredisease/pull/757)
 
 ### Parameters
 

--- a/conf/modules/prepare_references.config
+++ b/conf/modules/prepare_references.config
@@ -105,7 +105,7 @@ process {
     }
 
     withName: '.*PREPARE_REFERENCES:BEDTOOLS_PAD_TARGET_BED' {
-        ext.when   = { params.target_bed && params.bait_padding > 0 }
+        ext.when   = { params.target_bed }
         ext.prefix = { "${meta.id}_pad${params.bait_padding}" }
         ext.args   = { "-b ${params.bait_padding}" }
     }


### PR DESCRIPTION
When bait padding is zet to zero, the prepare_references subworkflow does not produce an output file, which causes deepvariant to fail. This PR makes it so the bedtools slop module is run even when bait padding is zero, essentially copying the input bed file.

Local test shows inputting 0 works for the tool:
<img width="750" height="154" alt="image" src="https://github.com/user-attachments/assets/b11b8350-ca34-481d-ace8-021ebe17610a" />


Closes: https://github.com/nf-core/raredisease/issues/719

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/raredisease _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test_singleton,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
