### PR TITLE
vcf2cytosure add genome build switch

### DIFF
--- a/conf/modules/generate_cytosure_files.config
+++ b/conf/modules/generate_cytosure_files.config
@@ -42,7 +42,8 @@ process {
         ext.args = { [
             meta.sex == 1 ? '--sex male' : '--sex female',
             '--size 5000',
-            '--maxbnd 5000'
+            '--maxbnd 5000',
+            params.genome.equals("GRCh38") ? "--genome 38" : ""
             ].join(' ') }
         ext.prefix = { "${meta.custid}" ? "${meta.custid}" : "${meta.id}" }
     }


### PR DESCRIPTION
If the raredisease pipeline is run with hg38, it should add a flag for this in the vcf2cytosure command.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/raredisease _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test_singleton,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
