### PR TITLE
Simplify MT conditional logic across workflow signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
+- Pre-resolve the MT analysis flag (`val_analysis_type.matches("wgs|mito") || val_run_mt_for_wes`) into a single named boolean `val_run_mt` in `NFCORE_RAREDISEASE`, replacing `val_run_mt_for_wes` across downstream subworkflow signatures and simplifying repeated conditionals in `PREPARE_REFERENCES`, `ALIGN`, `CALL_SNV`, and `CALL_STRUCTURAL_VARIANTS` [#906](https://github.com/nf-core/raredisease/pull/906)
 - Replace `ch_publish`/`subworkflow_results` with named typed channel emits for fastqc, smncopynumbercaller, peddy, multiqc, and pedigree; remove legacy `publish` emit from `raredisease.nf` [#903](https://github.com/nf-core/raredisease/pull/903)
 - Replace `ch_publish`/`subworkflow_results` with named typed channel emits for `annotate_structural_variants` subworkflow [#902](https://github.com/nf-core/raredisease/pull/902)
 - Replace `ch_publish`/`subworkflow_results` with named typed channel emits for gens and generate_cytosure_files subworkflows [#899](https://github.com/nf-core/raredisease/pull/899)

--- a/main.nf
+++ b/main.nf
@@ -120,7 +120,6 @@ workflow NFCORE_RAREDISEASE {
     val_sample_id_map
     val_save_all_mapped_as_cram
     val_save_noalt_mapped_as_cram
-    val_save_reference
     val_score_config_mt
     val_score_config_snv
     val_score_config_sv
@@ -160,10 +159,10 @@ workflow NFCORE_RAREDISEASE {
     //
 
     ch_versions = channel.empty()
+    def val_run_mt = val_analysis_type.matches("wgs|mito") || val_run_mt_for_wes
 
     PREPARE_REFERENCES (
         val_aligner,
-        val_analysis_type,
         val_bwa,
         val_bwafastalign,
         val_bwamem2,
@@ -176,7 +175,7 @@ workflow NFCORE_RAREDISEASE {
         val_known_dbsnp_tbi,
         val_mt_aligner,
         val_mt_fasta,
-        val_run_mt_for_wes,
+        val_run_mt,
         val_run_rtgvcfeval,
         val_sdf,
         val_sequence_dictionary,
@@ -546,7 +545,7 @@ workflow NFCORE_RAREDISEASE {
         val_multiqc_samples,
         val_outdir,
         val_platform,
-        val_run_mt_for_wes,
+        val_run_mt,
         val_run_rtgvcfeval,
         val_run_vcfanno_db_sanity_check,
         val_sample_id_map,
@@ -808,7 +807,6 @@ workflow {
         params.sample_id_map,
         params.save_all_mapped_as_cram,
         params.save_noalt_mapped_as_cram,
-        params.save_reference,
         params.score_config_mt,
         params.score_config_snv,
         params.score_config_sv,

--- a/subworkflows/local/align/main.nf
+++ b/subworkflows/local/align/main.nf
@@ -35,12 +35,11 @@ workflow ALIGN {
         ch_mtshift_fasta              // channel: [mandatory] [ val(meta), path(fasta) ]
         skip_fastp                    // boolean
         val_aligner                   //  string:  'bwa', 'bwafastalign', 'bwamem2', 'bwameme', or 'sentieon'
-        val_analysis_type             //  string:  'wgs', 'wes', or 'mito'
         val_exclude_alt               // boolean
         val_extract_alignments        // boolean
         val_mt_aligner                //  string:  'bwa', 'bwamem2', or 'sentieon'
         val_platform                  //  string:  [mandatory] illumina or a different technology
-        val_run_mt_for_wes            // boolean
+        val_run_mt                    // boolean: true if MT analysis will run
         val_save_all_mapped_as_cram   // boolean
         val_save_noalt_mapped_as_cram // boolean
 
@@ -144,7 +143,7 @@ workflow ALIGN {
 
         // PREPARING READS FOR MT ALIGNMENT
 
-        if (val_analysis_type.matches("wgs|mito") || val_run_mt_for_wes) {
+        if (val_run_mt) {
             CONVERT_MT_BAM_TO_FASTQ (
                 ch_genome_marked_bam_bai,
                 ch_genome_dictionary,

--- a/subworkflows/local/align/tests/main.nf.test
+++ b/subworkflows/local/align/tests/main.nf.test
@@ -114,14 +114,13 @@ nextflow_workflow {
                 input[18] = channel.of([id:'shiftmt'], file(params.pipelines_testdata_base_path + 'reference/reference_mt.fa', checkIfExists: true)).collect()
                 input[19] = false
                 input[20] = "bwamem2"
-                input[21] = "wgs"
-                input[22] = true
-                input[23] = false
-                input[24] = "bwamem2"
-                input[25] = "illumina"
-                input[26] = false
+                input[21] = true
+                input[22] = false
+                input[23] = "bwamem2"
+                input[24] = "illumina"
+                input[25] = true
+                input[26] = true
                 input[27] = true
-                input[28] = true
                 """
             }
         }
@@ -221,14 +220,13 @@ nextflow_workflow {
                 input[18] = channel.of([id:'shiftmt'], file(params.pipelines_testdata_base_path + 'reference/reference_mt.fa', checkIfExists: true)).collect()
                 input[19] = false
                 input[20] = "bwamem2"
-                input[21] = "wes"
+                input[21] = false
                 input[22] = false
-                input[23] = false
-                input[24] = "bwamem2"
-                input[25] = "illumina"
-                input[26] = false
-                input[27] = true
-                input[28] = false
+                input[23] = "bwamem2"
+                input[24] = "illumina"
+                input[25] = false
+                input[26] = true
+                input[27] = false
                 """
             }
         }
@@ -319,14 +317,13 @@ nextflow_workflow {
                 input[18] = channel.of([id:'shiftmt'], file(params.pipelines_testdata_base_path + 'reference/reference_mt.fa', checkIfExists: true)).collect()
                 input[19] = true
                 input[20] = "bwameme"
-                input[21] = "wgs"
+                input[21] = false
                 input[22] = false
-                input[23] = false
-                input[24] = "bwamem2"
-                input[25] = "illumina"
-                input[26] = false
-                input[27] = true
-                input[28] = false
+                input[23] = "bwamem2"
+                input[24] = "illumina"
+                input[25] = true
+                input[26] = true
+                input[27] = false
                 """
             }
         }
@@ -419,14 +416,13 @@ nextflow_workflow {
                 input[18] = channel.of([id:'shiftmt'], file(params.pipelines_testdata_base_path + 'reference/reference_mt.fa', checkIfExists: true)).collect()
                 input[19] = true
                 input[20] = "bwameme"
-                input[21] = "wes"
+                input[21] = false
                 input[22] = false
-                input[23] = false
-                input[24] = "bwamem2"
-                input[25] = "illumina"
-                input[26] = false
-                input[27] = true
-                input[28] = false
+                input[23] = "bwamem2"
+                input[24] = "illumina"
+                input[25] = false
+                input[26] = true
+                input[27] = false
                 """
             }
         }

--- a/subworkflows/local/call_snv/main.nf
+++ b/subworkflows/local/call_snv/main.nf
@@ -38,7 +38,7 @@ workflow CALL_SNV {
         ch_target_bed             // channel: [mandatory] [ val(meta), path(bed), path(index) ]
         val_analysis_type             // string:  'wgs', 'wes', or 'mito'
         val_concatenate_snv_calls     // boolean
-        val_run_mt_for_wes            // boolean
+        val_run_mt                    // boolean: true if MT analysis will run
         val_skip_split_multiallelics  // boolean
         val_variant_caller            // string:  'deepvariant' or 'sentieon'
 
@@ -113,7 +113,7 @@ workflow CALL_SNV {
         ch_genome_tabix     = GATK4_SELECTVARIANTS.out.tbi
         ch_genome_vcf_tabix = ch_genome_vcf.join(ch_genome_tabix, failOnMismatch:true, failOnDuplicate:true)
 
-        if (val_analysis_type.matches("wgs|mito") || val_run_mt_for_wes) {
+        if (val_run_mt) {
             CALL_SNV_MT(
                 ch_mt_bam_bai,
                 ch_mt_dictionary,

--- a/subworkflows/local/call_snv/tests/main.nf.test
+++ b/subworkflows/local/call_snv/tests/main.nf.test
@@ -58,7 +58,7 @@ nextflow_workflow {
                 input[23] = channel.of([[id:'target'], [], []])
                 input[24] = 'wgs'
                 input[25] = false
-                input[26] = false
+                input[26] = true
                 input[27] = false
                 input[28] = 'deepvariant'
                 """
@@ -125,7 +125,7 @@ nextflow_workflow {
                 input[23] = channel.of([[id:'target'], [], []])
                 input[24] = 'wgs'
                 input[25] = true
-                input[26] = false
+                input[26] = true
                 input[27] = false
                 input[28] = 'deepvariant'
                 """

--- a/subworkflows/local/call_snv/tests/main.nf.test.snap
+++ b/subworkflows/local/call_snv/tests/main.nf.test.snap
@@ -16,7 +16,7 @@
                 "justhusky_mitochondria.vcf.gz.tbi"
             ]
         ],
-        "timestamp": "2026-05-30T00:18:20.446833954",
+        "timestamp": "2026-07-02T17:41:58.064361793",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -243,7 +243,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-06-22T12:57:59.006104185",
+        "timestamp": "2026-07-02T17:43:07.089299319",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/subworkflows/local/call_structural_variants/main.nf
+++ b/subworkflows/local/call_structural_variants/main.nf
@@ -47,7 +47,7 @@ workflow CALL_STRUCTURAL_VARIANTS {
         val_mitochondria_name                 // string: [mandatory] mito_name
         val_mitosalt_flank                    // string: [mandatory] mitosalt_flank
         val_mitosalt_heteroplasmy_limit       // string: [mandatory] mitosalt_heteroplasmy_limit
-        val_run_mt_for_wes                    // boolean: [mandatory] run_mt_for_wes
+        val_run_mt                            // boolean: true if MT analysis will run
 
     main:
         ch_cnvnator_vcf    = channel.empty()
@@ -88,7 +88,7 @@ workflow CALL_STRUCTURAL_VARIANTS {
 
         }
 
-        if (val_analysis_type.matches("wgs|mito") || val_run_mt_for_wes) {
+        if (val_run_mt) {
             CALL_SV_MT(
                 ch_mt_bam_bai,
                 ch_case_info,

--- a/subworkflows/local/prepare_references/main.nf
+++ b/subworkflows/local/prepare_references/main.nf
@@ -38,7 +38,6 @@ include { UNTAR as UNTAR_VEP_CACHE                          } from '../../../mod
 workflow PREPARE_REFERENCES {
     take:
         val_aligner                  // String: "bwa", "bwafastalign", "bwamem2", "sentieon" or "bwameme"
-        val_analysis_type            // String: "wgs", "wes", or "mito"
         val_bwa                      // String: path to bwa index
         val_bwafastalign             // String: path to bwafastalign index
         val_bwamem2                  // String: path to bwamem2 index
@@ -51,7 +50,7 @@ workflow PREPARE_REFERENCES {
         val_known_dbsnp_tbi          // String: path to dbsnp file's index
         val_mtaligner                // String: "bwa", "bwamem2", or "sentieon"
         val_mtfasta                  // String: path to mitochondrial fasta
-        val_run_mt_for_wes           // Boolean
+        val_run_mt                   // boolean: true if MT analysis will run
         val_run_rtgvcfeval           // Boolean
         val_sdf                      // String: path to sdf file
         val_genome_dict              // String: path to genome dictionary
@@ -143,7 +142,7 @@ workflow PREPARE_REFERENCES {
         //
         // MT genome indices
         //
-        if (val_analysis_type.matches("wgs|mito") || val_run_mt_for_wes) {
+        if (val_run_mt) {
             if (!val_mtfasta) {
                 ch_mt_fasta = SAMTOOLS_EXTRACT_MT(ch_genome_fasta.join(ch_genome_fai), false).fa.collect()
             } else {
@@ -181,15 +180,15 @@ workflow PREPARE_REFERENCES {
         //
         // MT alignment indices
         //
-        if ((val_analysis_type.matches("wgs|mito") || val_run_mt_for_wes) && val_mtaligner.equals("bwamem2")) {
+        if (val_run_mt && val_mtaligner.equals("bwamem2")) {
             ch_mt_bwamem2_index      = BWAMEM2_INDEX_MT(ch_mt_fasta).index.collect()
             ch_mtshift_bwamem2_index = BWAMEM2_INDEX_MT_SHIFT(ch_mtshift_fasta).index.collect()
         }
-        if ((val_analysis_type.matches("wgs|mito") || val_run_mt_for_wes) && val_mtaligner.equals("bwa")) {
+        if (val_run_mt && val_mtaligner.equals("bwa")) {
             ch_mt_bwa_index          = BWA_INDEX_MT(ch_mt_fasta).index.collect()
             ch_mtshift_bwa_index     = BWA_INDEX_MT_SHIFT(ch_mtshift_fasta).index.collect()
         }
-        if ((val_analysis_type.matches("wgs|mito") || val_run_mt_for_wes) && val_mtaligner.equals("sentieon")) {
+        if (val_run_mt && val_mtaligner.equals("sentieon")) {
             ch_mt_bwa_index          = SENTIEON_BWAINDEX_MT(ch_mt_fasta).index.collect()
             ch_mtshift_bwa_index     = SENTIEON_BWAINDEX_MT_SHIFT(ch_mtshift_fasta).index.collect()
         }

--- a/subworkflows/local/prepare_references/tests/main.nf.test
+++ b/subworkflows/local/prepare_references/tests/main.nf.test
@@ -40,20 +40,20 @@ nextflow_workflow {
             workflow {
                 """
                 input[0]  = "bwamem2"
-                input[1]  = "wgs"
+                input[1]  = null
                 input[2]  = null
                 input[3]  = null
                 input[4]  = null
                 input[5]  = null
-                input[6]  = null
-                input[7]  = params.pipelines_testdata_base_path + 'reference/reference.fasta'
-                input[8]  = params.pipelines_testdata_base_path + 'reference/gnomad_reformated.tab.gz'
+                input[6]  = params.pipelines_testdata_base_path + 'reference/reference.fasta'
+                input[7]  = params.pipelines_testdata_base_path + 'reference/gnomad_reformated.tab.gz'
+                input[8]  = null
                 input[9]  = null
                 input[10] = params.pipelines_testdata_base_path + 'reference/dbsnp_-138-.vcf.gz'
                 input[11] = null
                 input[12] = "bwa"
                 input[13] = null
-                input[14] = false
+                input[14] = true
                 input[15] = false
                 input[16] = null
                 input[17] = null
@@ -122,20 +122,20 @@ nextflow_workflow {
             workflow {
                 """
                 input[0]  = "bwamem2"
-                input[1]  = "wgs"
+                input[1]  = null
                 input[2]  = null
                 input[3]  = null
                 input[4]  = null
                 input[5]  = null
-                input[6]  = null
-                input[7]  = params.pipelines_testdata_base_path + 'reference/reference.fasta'
-                input[8]  = params.pipelines_testdata_base_path + 'reference/gnomad_reformated.tab.gz'
+                input[6]  = params.pipelines_testdata_base_path + 'reference/reference.fasta'
+                input[7]  = params.pipelines_testdata_base_path + 'reference/gnomad_reformated.tab.gz'
+                input[8]  = null
                 input[9]  = null
                 input[10] = params.pipelines_testdata_base_path + 'reference/dbsnp_-138-.vcf.gz'
                 input[11] = null
                 input[12] = "bwa"
                 input[13] = null
-                input[14] = false
+                input[14] = true
                 input[15] = false
                 input[16] = null
                 input[17] = null

--- a/workflows/raredisease.nf
+++ b/workflows/raredisease.nf
@@ -221,7 +221,7 @@ workflow RAREDISEASE {
     val_multiqc_samples
     val_outdir
     val_platform
-    val_run_mt_for_wes
+    val_run_mt
     val_run_rtgvcfeval
     val_run_vcfanno_db_sanity_check
     val_sample_id_map
@@ -370,12 +370,11 @@ workflow RAREDISEASE {
         ch_mtshift_fasta,
         skip_fastp,
         val_aligner,
-        val_analysis_type,
         val_exclude_alt,
         val_extract_alignments,
         val_mt_aligner,
         val_platform,
-        val_run_mt_for_wes,
+        val_run_mt,
         val_save_all_mapped_as_cram,
         val_save_noalt_mapped_as_cram
     )
@@ -387,7 +386,7 @@ workflow RAREDISEASE {
     ch_align_genome_marked_crai     = ALIGN.out.genome_marked_crai
     ch_align_markdup_metrics        = ALIGN.out.markdup_metrics
 
-    if (!(skip_mt_subsample) && (val_analysis_type.equals("wgs") || val_run_mt_for_wes)) {
+    if (!skip_mt_subsample && val_run_mt) {
         if (val_mt_subsample_approach.equals("fraction")) {
             SUBSAMPLE_MT_FRAC(
                 ch_mapped.mt_bam_bai,
@@ -532,7 +531,7 @@ workflow RAREDISEASE {
             ch_target_bed,
             val_analysis_type,
             val_concatenate_snv_calls,
-            val_run_mt_for_wes,
+            val_run_mt,
             val_skip_split_multiallelics,
             val_variant_caller
         )
@@ -547,7 +546,8 @@ workflow RAREDISEASE {
 
         // Removes vcfanno resource with empty records to keep vcfanno from crashing on those files
         ch_vcfanno_toml_final = ch_vcfanno_toml
-        if (val_run_vcfanno_db_sanity_check && (!skip_snv_annotation || (!skip_mt_annotation && (val_run_mt_for_wes || val_analysis_type.matches("wgs|mito"))))) {
+        def annotation_uses_vcfanno = !skip_snv_annotation || (!skip_mt_annotation && val_run_mt)
+        if (val_run_vcfanno_db_sanity_check && annotation_uses_vcfanno) {
             ch_vcfanno_resources
                 .combine(ch_vcfanno_extra)
                 .map { files -> files.flatten() }
@@ -642,7 +642,7 @@ workflow RAREDISEASE {
         //
         // ANNOTATE MT SNVs
         //
-        if (!(skip_mt_annotation) && (val_run_mt_for_wes || val_analysis_type.matches("wgs|mito"))) {
+        if (!skip_mt_annotation && val_run_mt) {
 
             ANNOTATE_MT_SNVS (
                 ch_cadd_header,
@@ -769,7 +769,7 @@ workflow RAREDISEASE {
             val_mito_name,
             val_mitosalt_flank,
             val_mitosalt_heteroplasmy_limit,
-            val_run_mt_for_wes
+            val_run_mt
         )
         ch_call_sv_vcf = CALL_STRUCTURAL_VARIANTS.out.vcf
         ch_call_sv_tbi = CALL_STRUCTURAL_VARIANTS.out.tbi


### PR DESCRIPTION
Pre-resolve val_run_mt in NFCORE_RAREDISEASE and pass it downstream, replacing val_run_mt_for_wes across PREPARE_REFERENCES, ALIGN, CALL_SNV, and CALL_STRUCTURAL_VARIANTS. Drop unused val_analysis_type from PREPARE_REFERENCES and ALIGN, and val_save_reference from NFCORE_RAREDISEASE. Decompose the vcfanno sanity-check guard into a named intermediate. Update all affected tests and changelog.

<!--
# nf-core/raredisease pull request

Many thanks for contributing to nf-core/raredisease!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/raredisease _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test_singleton,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
