### PR TITLE
warn when vep_filters file contains no records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- Emit a warning at startup when `vep_filters_scout_fmt` or `vep_filters` contains no records (headers or empty lines only), which would otherwise cause the clinical set to silently contain 0 variants [#729](https://github.com/nf-core/raredisease/issues/729)
 - Fix intermittent `CALL_SNV_DEEPVARIANT - wgs` test failure caused by non-deterministic GLnexus quality scores by replacing `variantsMD5` with `vcf.summary` [#850](https://github.com/nf-core/raredisease/pull/850)
 - Fix swapped `run_mt_for_wes`/`skip_split_multiallelics` arguments in the `CALL_SNV` call, which disabled multiallelic splitting (and inverted MT-for-WES) when `--run_mt_for_wes` was set [#854](https://github.com/nf-core/raredisease/issues/854)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- Emit a warning at startup when `vep_filters_scout_fmt` or `vep_filters` contains no records (headers or empty lines only), which would otherwise cause the clinical set to silently contain 0 variants [#729](https://github.com/nf-core/raredisease/issues/729)
+- Emit an error at startup when `vep_filters_scout_fmt` or `vep_filters` contains no records (headers or empty lines only), which would otherwise cause the clinical set to silently contain 0 variants [#913](https://github.com/nf-core/raredisease/pull/913)
 - Fix intermittent `CALL_SNV_DEEPVARIANT - wgs` test failure caused by non-deterministic GLnexus quality scores by replacing `variantsMD5` with `vcf.summary` [#850](https://github.com/nf-core/raredisease/pull/850)
 - Fix swapped `run_mt_for_wes`/`skip_split_multiallelics` arguments in the `CALL_SNV` call, which disabled multiallelic splitting (and inverted MT-for-WES) when `--run_mt_for_wes` was set [#854](https://github.com/nf-core/raredisease/issues/854)
 

--- a/subworkflows/local/utils_nfcore_raredisease_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_raredisease_pipeline/main.nf
@@ -394,6 +394,12 @@ def checkRequiredParameters(params) {
         } else if (params.vep_filters && params.vep_filters_scout_fmt) {
             println("Either params.vep_filters or params.vep_filters_scout_fmt should be set.")
             missingParamsCount += 1
+        } else {
+            def filtersFile = params.vep_filters_scout_fmt ?: params.vep_filters
+            def nonHeaderLines = file(filtersFile).readLines().count { line -> !line.startsWith('#') && line.trim() }
+            if (nonHeaderLines == 0) {
+                error("The file '${filtersFile}' contains no records (only headers or empty lines). The clinical set will contain 0 variants.")
+            }
         }
     }
 


### PR DESCRIPTION
<!--
# nf-core/raredisease pull request

Many thanks for contributing to nf-core/raredisease!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
-->

When `vep_filters_scout_fmt` or `vep_filters` is provided as an empty file (headers only), `create_hgncids_file.py` silently produces an empty HGNC ID list, causing the clinical set to contain 0 variants with no indication that anything went wrong.

This adds a startup check in the pipeline validation step that reads the provided filter file and emits an `error` if it contains no non-comment, non-empty lines.

Screenshot of an error with empty file
<img width="796" height="239" alt="Screenshot 2026-07-04 at 11 26 56" src="https://github.com/user-attachments/assets/411a1581-6bb3-4058-9efb-61f4dd6078ee" />


## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/raredisease _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test_singleton,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
