### PR TITLE
add filter logic for mt snv merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - Fix `svdb/merge` mislabelling VCF caller tags by passing `sort_inputs = false` to `SVDB_MERGE` in `call_structural_variants`; the VCF list is already in the correct caller-priority order from the upstream `concat` chain, so in-module re-sorting by filename was causing tag misassignment [#910](https://github.com/nf-core/raredisease/pull/910)
+- Changed filter logic for merging mitochondrial snvs to report variants which pass filter in at least one sample [#915](https://github.com/nf-core/raredisease/pull/915)
 
 ## 3.1.1 - Princess Peach (patch) [2026-06-24]
 

--- a/conf/modules/postprocess_MT_calls.config
+++ b/conf/modules/postprocess_MT_calls.config
@@ -41,7 +41,7 @@ process {
     }
 
     withName: '.*POSTPROCESS_MT_CALLS:BCFTOOLS_MERGE_MT' {
-        ext.args = '--output-type z  --write-index=tbi'
+        ext.args = '--output-type z --write-index=tbi --filter-logic x'
         ext.prefix = { "${meta.id}_split_rmdup_merged" }
     }
 


### PR DESCRIPTION
<!--
# nf-core/raredisease pull request

Many thanks for contributing to nf-core/raredisease!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
-->

Add filter logic when merging mitochondrial SNV vcfs, so that variants that pass filter in any sample are reported in the merged case-level vcf. Part of https://github.com/Clinical-Genomics/raredisease/issues/37, in which variants were being filtered out because of not passing filter in the father.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/raredisease _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test_singleton,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
