### PR TITLE
Add vcf entrypoint schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 - Add CRAM file input support: accept `cram`/`crai` columns in the samplesheet, converting CRAM to BAM early in the align subworkflow so all downstream tools remain unchanged [#261](https://github.com/nf-core/raredisease/issues/261)
+- Add `vcf`/`tbi`/`type` columns to the samplesheet schema, enforcing exactly one data type per row (`fastq`, `spring`, `bam`, `cram`, or `vcf`) via a schema-level `oneOf` constraint, and extend `PIPELINE_INITIALISATION` to recognise precalled SNV/SV/MT VCFs and collect them into a new `precalled_vcfs` channel (Only schema/plumbing changes in this PR) [Issue #261](https://github.com/nf-core/raredisease/issues/261) and [PR #927](https://github.com/nf-core/raredisease/pull/927)
 - Add `changelog.yml` GitHub Actions workflow to enforce CHANGELOG updates on every PR; PRs can be exempted with the `skip-changelog` label [issue #796](https://github.com/nf-core/raredisease/issues/796) [PR #920](https://github.com/nf-core/raredisease/pull/920)
 - Update saltshaker classification reporting by adding customer ID to samples' reports and displaying them as tabs in html [#856](https://github.com/nf-core/raredisease/pull/856)
 - Added non-stub tests for `annotate_mt_snvs` [#890](https://github.com/nf-core/raredisease/pull/890)

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -171,11 +171,61 @@
             }
         ],
         "oneOf": [
-            { "required": ["fastq_1"], "not": { "anyOf": [ {"required": ["spring_1"]}, {"required": ["bam"]}, {"required": ["cram"]}, {"required": ["vcf"]} ] } },
-            { "required": ["spring_1"], "not": { "anyOf": [ {"required": ["fastq_1"]}, {"required": ["bam"]}, {"required": ["cram"]}, {"required": ["vcf"]} ] } },
-            { "required": ["bam"], "not": { "anyOf": [ {"required": ["fastq_1"]}, {"required": ["spring_1"]}, {"required": ["cram"]}, {"required": ["vcf"]} ] } },
-            { "required": ["cram"], "not": { "anyOf": [ {"required": ["fastq_1"]}, {"required": ["spring_1"]}, {"required": ["bam"]}, {"required": ["vcf"]} ] } },
-            { "required": ["vcf"], "not": { "anyOf": [ {"required": ["fastq_1"]}, {"required": ["spring_1"]}, {"required": ["bam"]}, {"required": ["cram"]} ] } }
+            {
+                "required": ["fastq_1"],
+                "not": {
+                    "anyOf": [
+                        { "required": ["spring_1"] },
+                        { "required": ["bam"] },
+                        { "required": ["cram"] },
+                        { "required": ["vcf"] }
+                    ]
+                }
+            },
+            {
+                "required": ["spring_1"],
+                "not": {
+                    "anyOf": [
+                        { "required": ["fastq_1"] },
+                        { "required": ["bam"] },
+                        { "required": ["cram"] },
+                        { "required": ["vcf"] }
+                    ]
+                }
+            },
+            {
+                "required": ["bam"],
+                "not": {
+                    "anyOf": [
+                        { "required": ["fastq_1"] },
+                        { "required": ["spring_1"] },
+                        { "required": ["cram"] },
+                        { "required": ["vcf"] }
+                    ]
+                }
+            },
+            {
+                "required": ["cram"],
+                "not": {
+                    "anyOf": [
+                        { "required": ["fastq_1"] },
+                        { "required": ["spring_1"] },
+                        { "required": ["bam"] },
+                        { "required": ["vcf"] }
+                    ]
+                }
+            },
+            {
+                "required": ["vcf"],
+                "not": {
+                    "anyOf": [
+                        { "required": ["fastq_1"] },
+                        { "required": ["spring_1"] },
+                        { "required": ["bam"] },
+                        { "required": ["cram"] }
+                    ]
+                }
+            }
         ],
         "dependentRequired": {
             "fastq_2": ["fastq_1"],

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -82,6 +82,25 @@
                 "format": "file-path",
                 "exists": true
             },
+            "vcf": {
+                "errorMessage": "Precalled VCF must be bgzipped, cannot contain spaces, and must have extension '.vcf.gz'",
+                "type": "string",
+                "pattern": "^\\S+\\.vcf\\.gz$",
+                "format": "file-path",
+                "exists": true
+            },
+            "tbi": {
+                "errorMessage": "Precalled VCF index file cannot contain spaces and must have extension '.vcf.gz.tbi'",
+                "type": "string",
+                "pattern": "^\\S+\\.vcf\\.gz\\.tbi$",
+                "format": "file-path",
+                "exists": true
+            },
+            "type": {
+                "errorMessage": "Precalled VCF type must be one of 'snv', 'sv', 'mt'",
+                "type": "string",
+                "enum": ["snv", "sv", "mt"]
+            },
             "sex": {
                 "anyOf": [
                     {
@@ -151,11 +170,21 @@
                 }
             }
         ],
+        "oneOf": [
+            { "required": ["fastq_1"], "not": { "anyOf": [ {"required": ["spring_1"]}, {"required": ["bam"]}, {"required": ["cram"]}, {"required": ["vcf"]} ] } },
+            { "required": ["spring_1"], "not": { "anyOf": [ {"required": ["fastq_1"]}, {"required": ["bam"]}, {"required": ["cram"]}, {"required": ["vcf"]} ] } },
+            { "required": ["bam"], "not": { "anyOf": [ {"required": ["fastq_1"]}, {"required": ["spring_1"]}, {"required": ["cram"]}, {"required": ["vcf"]} ] } },
+            { "required": ["cram"], "not": { "anyOf": [ {"required": ["fastq_1"]}, {"required": ["spring_1"]}, {"required": ["bam"]}, {"required": ["vcf"]} ] } },
+            { "required": ["vcf"], "not": { "anyOf": [ {"required": ["fastq_1"]}, {"required": ["spring_1"]}, {"required": ["bam"]}, {"required": ["cram"]} ] } }
+        ],
         "dependentRequired": {
             "fastq_2": ["fastq_1"],
             "spring_2": ["spring_1"],
             "bam": ["bai"],
-            "cram": ["crai"]
+            "cram": ["crai"],
+            "vcf": ["tbi", "type"],
+            "tbi": ["vcf", "type"],
+            "type": ["vcf", "tbi"]
         },
         "required": ["sample", "sex", "phenotype", "case_id"]
     }

--- a/subworkflows/local/utils_nfcore_raredisease_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_raredisease_pipeline/main.nf
@@ -110,13 +110,13 @@ workflow PIPELINE_INITIALISATION {
     channel
         .fromList(samplesheetToList(input, "${projectDir}/assets/schema_input.json"))
         .tap { ch_original_input }
-        .map { meta, _fastq1, _fastq2, _spring1, _spring2, _bam, _bai, _cram, _crai -> meta.id }
+        .map { meta, _fastq1, _fastq2, _spring1, _spring2, _bam, _bai, _cram, _crai, _vcf, _tbi, _type -> meta.id }
         .reduce([:]) { counts, sample -> //get counts of each sample in the samplesheet - for groupTuple
             counts[sample] = (counts[sample] ?: 0) + 1
             counts
         }
         .combine( ch_original_input )
-        .map { counts, meta, fastq1, fastq2, spring1, spring2, bam, bai, cram, crai ->
+        .map { counts, meta, fastq1, fastq2, spring1, spring2, bam, bai, cram, crai, vcf, tbi, type ->
             def new_meta = meta + [num_lanes:counts[meta.id]]
             if (fastq1 && fastq2) {
                 new_meta += [read_group: generateReadGroupLine(fastq1, meta, params)]
@@ -136,6 +136,8 @@ workflow PIPELINE_INITIALISATION {
             } else if (cram && crai) {
                 new_meta += [read_group: generateReadGroupLine(cram, meta, params)]
                 return [new_meta + [data_type: "cram"], [cram, crai]]
+            } else if (vcf && tbi && type) {
+                return [new_meta + [data_type: "${type}_vcf"], [vcf, tbi]]
             }
         }
         .tap{ ch_input_counts }
@@ -151,9 +153,11 @@ workflow PIPELINE_INITIALISATION {
         }
         .tap { ch_samplesheet }
         .branch { meta, files  ->
-            fastq: !files[0].toString().endsWith("bam") && !files[0].toString().endsWith("cram")
+            fastq:     meta.data_type in ["fastq_gz", "separate_spring", "interleaved_spring"]
                 return [meta, files]
-            align: files[0].toString().endsWith("bam") || files[0].toString().endsWith("cram")
+            align:     meta.data_type in ["bam", "cram"]
+                return [meta, files]
+            precalled: meta.data_type.endsWith("_vcf")
                 return [meta, files]
         }
         .set {ch_samplesheet_by_type}
@@ -166,12 +170,17 @@ workflow PIPELINE_INITIALISATION {
 
     ch_case_info = ch_samples.toList().map { it -> createCaseChannel(it) }
 
+    ch_precalled_vcfs = ch_samplesheet_by_type.precalled
+        .toList()
+        .map { rows -> extractPrecalledVcfs(rows) }
+
     emit:
-    reads     = ch_samplesheet_by_type.fastq
-    align     = ch_samplesheet_by_type.align
-    samples   = ch_samples
-    case_info = ch_case_info
-    versions  = ch_versions
+    reads          = ch_samplesheet_by_type.fastq // channel: [ val(meta), [ path(reads) ] ]
+    align          = ch_samplesheet_by_type.align // channel: [ val(meta), [ path(bam/cram), path(bai/crai) ] ]
+    samples        = ch_samples                   // channel: [ val(meta) ]
+    case_info      = ch_case_info                 // channel: [ val(case_info) ]
+    precalled_vcfs = ch_precalled_vcfs             // channel: [ val([snv:[vcf,tbi]|null, sv:[...]|null, mt:[...]|null]) ]
+    versions       = ch_versions                  // channel: [ path(versions) ]
 }
 
 /*
@@ -313,6 +322,19 @@ def createCaseChannel(List rows) {
     case_info.id           = rows[0].case_id
 
     return case_info
+}
+
+// Function to collect precalled vcf/tbi pairs per variant type from rows tagged with a "*_vcf" data_type
+def extractPrecalledVcfs(List rows) {
+    def precalled = [snv: null, sv: null, mt: null]
+    rows.each { meta, files ->
+        def type = meta.data_type - "_vcf"
+        if (precalled[type] && precalled[type] != files) {
+            error("Conflicting precalled '${type}' VCFs supplied in samplesheet for the same case.")
+        }
+        precalled[type] = files
+    }
+    return precalled
 }
 
 //


### PR DESCRIPTION
<!--
# nf-core/raredisease pull request

Many thanks for contributing to nf-core/raredisease!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
-->

Part of #261. A VCF entry point that lets users feed precalled SNV/SV/MT VCFs straight into annotation, skipping calling. 

Changes:
- New samplesheet columns: vcf, tbi, type (snv/sv/mt)
- Schema-level oneOf constraint: exactly one data type per row (fastq/spring/bam/cram/vcf), enforced before the pipeline starts
- PIPELINE_INITIALISATION gains a precalled branch and a new precalled_vcfs output channel collecting VCFs per case/type

Not in this PR: 
Nothing consumes precalled_vcfs yet. Calling/annotation wiring will happen in a future PR.

Tested: default, test_align, test_singleton all pass unchanged.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/raredisease _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test_singleton,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
