### PR TITLE
Add `me` as a fourth precalled-VCF type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
+- Extend the VCF entry point to a fourth type, `me` [issue #261](https://github.com/nf-core/raredisease/issues/261) [PR #TBD](https://github.com/nf-core/raredisease/pull/TBD)
 - Split `skip_mt_calling` into independently-gated `skip_mt_snv_calling` (gates `CALL_MT_SNVS` only, same behavior as before) and `skip_mt_sv_calling` (new tag gating `CALL_SV_MT` - MitoSalt/SaltShaker and the mitodel/MT-deletion script) [issue #950](https://github.com/nf-core/raredisease/issues/950) [PR #954](https://github.com/nf-core/raredisease/pull/954)
 - Extract the clinical-set-filter → CSQ/PLI-annotate → (proband-filter) → rank sequence, previously duplicated once each for SNV/MT/SV/ME in `raredisease.nf`, into a new `FILTER_ANNOTATE_RANK` subworkflow called four times under aliases [issue #952](https://github.com/nf-core/raredisease/issues/952) [PR #953](https://github.com/nf-core/raredisease/pull/953)
 - Split mitochondrial SV calling out of `CALL_STRUCTURAL_VARIANTS` into its own top-level `CALL_SV` (nuclear-only) and `CALL_SV_MT` (unchanged) subworkflows called independently from `raredisease.nf`, with the final nuclear+MT SVDB merge moved to the top level; matches how `CALL_SNV`/`CALL_MT_SNVS` are already split; behavior-preserving refactor [issue #948](https://github.com/nf-core/raredisease/issues/948) [PR #951](https://github.com/nf-core/raredisease/pull/951)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
-- Extend the VCF entry point to a fourth type, `me` [issue #261](https://github.com/nf-core/raredisease/issues/261) [PR #TBD](https://github.com/nf-core/raredisease/pull/TBD)
+- Extend the VCF entry point to a fourth type, `me` [issue #261](https://github.com/nf-core/raredisease/issues/261) [PR #955](https://github.com/nf-core/raredisease/pull/955)
 - Split `skip_mt_calling` into independently-gated `skip_mt_snv_calling` (gates `CALL_MT_SNVS` only, same behavior as before) and `skip_mt_sv_calling` (new tag gating `CALL_SV_MT` - MitoSalt/SaltShaker and the mitodel/MT-deletion script) [issue #950](https://github.com/nf-core/raredisease/issues/950) [PR #954](https://github.com/nf-core/raredisease/pull/954)
 - Extract the clinical-set-filter → CSQ/PLI-annotate → (proband-filter) → rank sequence, previously duplicated once each for SNV/MT/SV/ME in `raredisease.nf`, into a new `FILTER_ANNOTATE_RANK` subworkflow called four times under aliases [issue #952](https://github.com/nf-core/raredisease/issues/952) [PR #953](https://github.com/nf-core/raredisease/pull/953)
 - Split mitochondrial SV calling out of `CALL_STRUCTURAL_VARIANTS` into its own top-level `CALL_SV` (nuclear-only) and `CALL_SV_MT` (unchanged) subworkflows called independently from `raredisease.nf`, with the final nuclear+MT SVDB merge moved to the top level; matches how `CALL_SNV`/`CALL_MT_SNVS` are already split; behavior-preserving refactor [issue #948](https://github.com/nf-core/raredisease/issues/948) [PR #951](https://github.com/nf-core/raredisease/pull/951)

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -97,9 +97,9 @@
                 "exists": true
             },
             "type": {
-                "errorMessage": "Precalled VCF type must be one of 'snv', 'sv', 'mt'",
+                "errorMessage": "Precalled VCF type must be one of 'snv', 'sv', 'mt', 'me'",
                 "type": "string",
-                "enum": ["snv", "sv", "mt"]
+                "enum": ["snv", "sv", "mt", "me"]
             },
             "sex": {
                 "anyOf": [

--- a/conf/test_vcf.config
+++ b/conf/test_vcf.config
@@ -3,7 +3,7 @@
     Nextflow config file for running minimal tests from precalled VCF input
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     Defines input files and everything required to run a fast and simple pipeline test
-    where SNV/SV/MT calling is skipped in favor of precalled VCFs supplied in the samplesheet.
+    where SNV/SV/MT/ME calling is skipped in favor of precalled VCFs supplied in the samplesheet.
 
     Use as follows:
         nextflow run nf-core/raredisease -profile test_vcf,<docker/singularity> --outdir <OUTDIR>
@@ -38,6 +38,7 @@ params {
     gnomad_af                       = params.pipelines_testdata_base_path + 'reference/gnomad_reformated.tab.gz'
     intervals_wgs                   = params.pipelines_testdata_base_path + 'reference/target_wgs.interval_list'
     intervals_y                     = params.pipelines_testdata_base_path + 'reference/targetY.interval_list'
+    mobile_element_svdb_annotations = params.pipelines_testdata_base_path + 'reference/svdb_querydb_files.csv'
     reduced_penetrance              = params.pipelines_testdata_base_path + 'reference/reduced_penetrance.tsv'
     score_config_mt                 = params.pipelines_testdata_base_path + 'reference/rank_model_snv.ini'
     score_config_snv                = params.pipelines_testdata_base_path + 'reference/rank_model_snv.ini'

--- a/docs/output.md
+++ b/docs/output.md
@@ -576,6 +576,8 @@ We recommend using vcfanno to annotate SNVs with precomputed CADD scores (files 
 
 #### Calling mobile elements
 
+> **NB**: This section is skipped if a precalled ME VCF is supplied in the samplesheet (see [Samplesheet for VCF file input](usage.md#samplesheet-for-vcf-file-input)); the supplied VCF is used directly for annotation instead, and no `call_mobile_elements/` output is produced.
+
 Mobile elements are identified from the bam file using [RetroSeq](https://github.com/tk2/RetroSeq) and the indiviual calls are merged to case VCF using SVDB.
 
 <details markdown="1">

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -178,22 +178,23 @@ The nf-core/raredisease pipeline can also accept precalled, case-level VCF files
 | `sample` | Custom sample name. This entry will be identical for multiple sequencing libraries/runs from the same sample. |
 | `vcf`    | Absolute path to a bgzipped, precalled VCF file (`.vcf.gz`).                                                  |
 | `tbi`    | Absolute path to the tabix index of the VCF file (`.vcf.gz.tbi`).                                             |
-| `type`   | The variant type contained in the VCF. One of `snv`, `sv`, or `mt`.                                           |
+| `type`   | The variant type contained in the VCF. One of `snv`, `sv`, `mt`, or `me`.                                     |
 
-Each precalled VCF must contain only the variant type it declares in `type`: a nuclear (non-mitochondrial) VCF for `snv`, an MT-only VCF for `mt`, and an SVDB-merged structural variant VCF for `sv`. Since a precalled VCF represents the whole case (it's already jointly called across the family, not a single sample), parents and other unaffected relatives are referenced purely through the existing `paternal_id`/`maternal_id` columns on the proband's row(s) and never get their own samplesheet row — they're assumed to already be genotyped inside the supplied VCF.
+Each precalled VCF must contain only the variant type it declares in `type`: a nuclear (non-mitochondrial) VCF for `snv`, an MT-only VCF for `mt`, an SVDB-merged structural variant VCF for `sv`, and an SVDB-merged mobile-element VCF (matching `CALL_MOBILE_ELEMENTS` output) for `me`. Since a precalled VCF represents the whole case (it's already jointly called across the family, not a single sample), parents and other unaffected relatives are referenced purely through the existing `paternal_id`/`maternal_id` columns on the proband's row(s) and never get their own samplesheet row — they're assumed to already be genotyped inside the supplied VCF.
 
-Below is an example samplesheet for a trio where all three variant types have been precalled for the case. Note that `father` and `mother` are referenced by ID only and never appear as their own rows:
+Below is an example samplesheet for a trio where all four variant types have been precalled for the case. Note that `father` and `mother` are referenced by ID only and never appear as their own rows:
 
 | sample  | vcf                | tbi                    | type | sex | phenotype | paternal_id | maternal_id | case_id |
 | ------- | ------------------ | ---------------------- | ---- | --- | --------- | ----------- | ----------- | ------- |
 | proband | proband_snv.vcf.gz | proband_snv.vcf.gz.tbi | snv  | 1   | 2         | father      | mother      | fam_1   |
 | proband | proband_sv.vcf.gz  | proband_sv.vcf.gz.tbi  | sv   | 1   | 2         | father      | mother      | fam_1   |
 | proband | proband_mt.vcf.gz  | proband_mt.vcf.gz.tbi  | mt   | 1   | 2         | father      | mother      | fam_1   |
+| proband | proband_me.vcf.gz  | proband_me.vcf.gz.tbi  | me   | 1   | 2         | father      | mother      | fam_1   |
 
 **What's possible:**
 
-- Supplying precalled VCFs for all variant types applicable to the case (`snv` + `sv` + `mt` for WGS/mito, or just `snv` + `sv` for WES without `--run_mt_for_wes`) to run annotation/ranking only, with no calling at all.
-- Supplying precalled VCFs for only a subset of types, as long as calling for the remaining type(s) is explicitly disabled with `--skip_subworkflows`. For example, a WGS case with only `snv`/`sv` VCFs needs `--skip_subworkflows mt_snv_calling` added on the command line, since MT calling would otherwise run by default for WGS but there's no alignment data to call it from.
+- Supplying precalled VCFs for all variant types applicable to the case (`snv` + `sv` + `mt` + `me` for WGS, `snv` + `sv` + `mt` for mito, or just `snv` + `sv` for WES without `--run_mt_for_wes`) to run annotation/ranking only, with no calling at all.
+- Supplying precalled VCFs for only a subset of types, as long as calling for the remaining type(s) is explicitly disabled with `--skip_subworkflows`. For example, a WGS case with only `snv`/`sv` VCFs needs `--skip_subworkflows mt_snv_calling,me_calling` added on the command line, since MT and mobile-element calling would otherwise run by default for WGS but there's no alignment data to call them from.
 - Mixing precalled and freshly-called cases across **different** runs/samplesheets — the restrictions below apply per case, not pipeline-wide.
 
 **What's not possible** (the pipeline validates these and errors out with a specific message rather than silently producing empty output):
@@ -201,7 +202,7 @@ Below is an example samplesheet for a trio where all three variant types have be
 - Mixing `vcf` rows with `fastq`/`spring`/`bam`/`cram` rows for the **same case**. A row in the samplesheet may only specify one data type (`fastq`, `spring`, `bam`, `cram`, or `vcf`) — mixing, for example, `fastq_1` and `vcf` in the same row is rejected by the schema — and a case as a whole must be either fully precalled or fully processed from raw/aligned reads, never both.
 - Leaving a variant type uncovered. If a case has any precalled VCF, every other type that's still relevant to the analysis must either also have a precalled VCF or have its calling explicitly skipped via `--skip_subworkflows` — the pipeline checks this upfront and errors out immediately, before any channels are built, naming exactly which type(s) are missing.
 - Supplying two different VCFs for the same `type` within the same case (conflicting precalled VCFs for one case).
-- A `type` value other than `snv`, `sv`, or `mt` (schema-enforced). Note there is no separate `mt_sv` type: nuclear and mitochondrial SV calls (MitoSalt/SaltShaker) are merged into one VCF before annotation/ranking, so a `sv` VCF is expected to already include mitochondrial SV calls if you want them represented — merge them in yourself before supplying it.
+- A `type` value other than `snv`, `sv`, `mt`, or `me` (schema-enforced). Note there is no separate `mt_sv` type: nuclear and mitochondrial SV calls (MitoSalt/SaltShaker) are merged into one VCF before annotation/ranking, so a `sv` VCF is expected to already include mitochondrial SV calls if you want them represented — merge them in yourself before supplying it.
 
 #### Reference files and parameters
 

--- a/main.nf
+++ b/main.nf
@@ -20,6 +20,7 @@ include { CREATE_PEDIGREE_FILE    } from './modules/local/create_pedigree_file'
 include { channelFromPath         } from './subworkflows/local/utils_nfcore_raredisease_pipeline'
 include { channelFromPathWithMeta } from './subworkflows/local/utils_nfcore_raredisease_pipeline'
 include { channelFromSamplesheet  } from './subworkflows/local/utils_nfcore_raredisease_pipeline'
+include { hasPrecalledMeVcf       } from './subworkflows/local/utils_nfcore_raredisease_pipeline'
 include { hasPrecalledMtVcf       } from './subworkflows/local/utils_nfcore_raredisease_pipeline'
 include { hasPrecalledSnvVcf      } from './subworkflows/local/utils_nfcore_raredisease_pipeline'
 include { hasPrecalledSvVcf       } from './subworkflows/local/utils_nfcore_raredisease_pipeline'
@@ -361,8 +362,9 @@ workflow NFCORE_RAREDISEASE {
     val_has_precalled_snv      = hasPrecalledSnvVcf()
     val_has_precalled_sv       = hasPrecalledSvVcf()
     val_has_precalled_mt       = hasPrecalledMtVcf()
+    val_has_precalled_me       = hasPrecalledMeVcf()
     skip_me_annotation         = parseSkipList(val_skip_subworkflows, 'me_annotation')
-    skip_me_calling            = parseSkipList(val_skip_subworkflows, 'me_calling')
+    skip_me_calling            = parseSkipList(val_skip_subworkflows, 'me_calling') || val_has_precalled_me
     skip_mt_annotation         = parseSkipList(val_skip_subworkflows, 'mt_annotation')
     skip_mt_snv_calling        = parseSkipList(val_skip_subworkflows, 'mt_snv_calling') || val_has_precalled_mt
     skip_mt_subsample          = parseSkipList(val_skip_subworkflows, 'mt_subsample')
@@ -529,6 +531,7 @@ workflow NFCORE_RAREDISEASE {
         val_exclude_alt,
         val_extract_alignments,
         val_genome,
+        val_has_precalled_me,
         val_has_precalled_mt,
         val_has_precalled_snv,
         val_has_precalled_sv,

--- a/subworkflows/local/utils_nfcore_raredisease_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_raredisease_pipeline/main.nf
@@ -181,7 +181,7 @@ workflow PIPELINE_INITIALISATION {
     align          = ch_samplesheet_by_type.align // channel: [ val(meta), [ path(bam/cram), path(bai/crai) ] ]
     samples        = ch_samples                   // channel: [ val(meta) ]
     case_info      = ch_case_info                 // channel: [ val(case_info) ]
-    precalled_vcfs = ch_precalled_vcfs             // channel: [ val([snv:[vcf,tbi]|null, sv:[...]|null, mt:[...]|null]) ]
+    precalled_vcfs = ch_precalled_vcfs             // channel: [ val([snv:[vcf,tbi]|null, sv:[...]|null, mt:[...]|null, me:[...]|null]) ]
     versions       = ch_versions                  // channel: [ path(versions) ]
 }
 
@@ -285,7 +285,7 @@ def boolean hasSpringInput() {
     return file(params.input).readLines().any { line -> line.contains('.spring') }
 }
 
-// Checks whether any samplesheet row has its 'type' column set to the given precalled-VCF type (snv/sv/mt)
+// Checks whether any samplesheet row has its 'type' column set to the given precalled-VCF type (snv/sv/mt/me)
 def boolean hasPrecalledVcfOfType(String type) {
     def lines = file(params.input).readLines()
     if (!lines) {
@@ -315,10 +315,14 @@ def boolean hasPrecalledMtVcf() {
     return hasPrecalledVcfOfType('mt')
 }
 
+def boolean hasPrecalledMeVcf() {
+    return hasPrecalledVcfOfType('me')
+}
+
 // True whenever the case is fully precalled for at least one type - since validateNoMixedCaseInput
 // guarantees such a case has zero fastq/bam/cram rows, this also means no alignment data exists at all
 def boolean hasAnyPrecalledVcf() {
-    return hasPrecalledSnvVcf() || hasPrecalledSvVcf() || hasPrecalledMtVcf()
+    return hasPrecalledSnvVcf() || hasPrecalledSvVcf() || hasPrecalledMtVcf() || hasPrecalledMeVcf()
 }
 
 def generateReadGroupLine(file, meta, params) {
@@ -378,7 +382,7 @@ def validateNoMixedCaseInput(List rows) {
 
 // Function to collect precalled vcf/tbi pairs per variant type from rows tagged with a "*_vcf" data_type
 def extractPrecalledVcfs(List rows) {
-    def precalled = [snv: null, sv: null, mt: null]
+    def precalled = [snv: null, sv: null, mt: null, me: null]
     rows.each { meta, files ->
         def type = meta.data_type - "_vcf"
         if (precalled[type] && precalled[type] != files) {
@@ -404,10 +408,12 @@ def validatePrecalledVcfCoverage() {
     def has_snv = hasPrecalledSnvVcf()
     def has_sv  = hasPrecalledSvVcf()
     def has_mt  = hasPrecalledMtVcf()
-    if (!has_snv && !has_sv && !has_mt) {
+    def has_me  = hasPrecalledMeVcf()
+    if (!has_snv && !has_sv && !has_mt && !has_me) {
         return
     }
     def run_mt  = params.analysis_type.matches("wgs|mito") || params.run_mt_for_wes
+    def run_me  = params.analysis_type.equals("wgs")
     def missing = []
     if (!has_snv && !parseSkipList(params.skip_subworkflows, 'snv_calling')) {
         missing << 'snv'
@@ -417,6 +423,9 @@ def validatePrecalledVcfCoverage() {
     }
     if (run_mt && !has_mt && !parseSkipList(params.skip_subworkflows, 'mt_snv_calling')) {
         missing << 'mt'
+    }
+    if (run_me && !has_me && !parseSkipList(params.skip_subworkflows, 'me_calling')) {
+        missing << 'me'
     }
     if (missing) {
         error("The samplesheet supplies a precalled VCF for at least one variant type, making this a fully-precalled case with no fastq/bam/cram input for calling. But no precalled VCF was supplied for: ${missing.join(', ')}. Either add a precalled VCF for ${missing.join(', ')}, or skip that calling explicitly via --skip_subworkflows.")
@@ -482,8 +491,10 @@ def checkRequiredParameters(params) {
     def all_skips = params.skip_subworkflows+","+params.skip_tools
     // These are all BAM/alignment-dependent auxiliary steps that are also skipped at runtime whenever
     // the case is fully precalled (no alignment data exists at all), even though that isn't reflected
-    // in --skip_tools/--skip_subworkflows, so their extra params shouldn't be forced mandatory either
-    def alignmentDependentConditions = ['repeat_calling', 'repeat_annotation', 'me_calling', 'me_annotation', 'gens', 'germlinecnvcaller']
+    // in --skip_tools/--skip_subworkflows, so their extra params shouldn't be forced mandatory either.
+    // me_annotation is deliberately excluded: like snv/sv/mt_annotation, it has its own precalled
+    // substitute and stays mandatory unless explicitly skipped, regardless of whether calling ran.
+    def alignmentDependentConditions = ['repeat_calling', 'repeat_annotation', 'me_calling', 'gens', 'germlinecnvcaller']
     dynamicRequirements.each { condition, paramsList ->
         def auto_skipped = condition in alignmentDependentConditions && hasAnyPrecalledVcf()
         if (!all_skips.split(',').contains(condition) && !auto_skipped) {

--- a/subworkflows/local/utils_nfcore_raredisease_pipeline/tests/main.function.nf.test
+++ b/subworkflows/local/utils_nfcore_raredisease_pipeline/tests/main.function.nf.test
@@ -89,7 +89,30 @@ nextflow_function {
                 { assert function.success },
                 { assert function.result.snv == ['snv.vcf.gz', 'snv.vcf.gz.tbi'] },
                 { assert function.result.sv  == ['sv.vcf.gz', 'sv.vcf.gz.tbi'] },
-                { assert function.result.mt  == null }
+                { assert function.result.mt  == null },
+                { assert function.result.me  == null }
+            )
+        }
+    }
+
+    test("extractPrecalledVcfs - includes me") {
+
+        function "extractPrecalledVcfs"
+
+        when {
+            function {
+                """
+                input[0] = [
+                    [[data_type: 'me_vcf'], ['me.vcf.gz', 'me.vcf.gz.tbi']]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert function.success },
+                { assert function.result.me == ['me.vcf.gz', 'me.vcf.gz.tbi'] }
             )
         }
     }
@@ -133,6 +156,38 @@ nextflow_function {
         }
     }
 
+    test("hasPrecalledMeVcf - present") {
+
+        function "hasPrecalledMeVcf"
+
+        when {
+            params {
+                input = "${projectDir}/subworkflows/local/utils_nfcore_raredisease_pipeline/tests/samplesheet_all_vcf_with_me.csv"
+            }
+        }
+
+        then {
+            assert function.success
+            assert function.result == true
+        }
+    }
+
+    test("hasPrecalledMeVcf - missing from partial samplesheet") {
+
+        function "hasPrecalledMeVcf"
+
+        when {
+            params {
+                input = "${projectDir}/subworkflows/local/utils_nfcore_raredisease_pipeline/tests/samplesheet_partial_vcf_no_me.csv"
+            }
+        }
+
+        then {
+            assert function.success
+            assert function.result == false
+        }
+    }
+
     test("hasPrecalledSnvVcf - no vcf rows at all") {
 
         function "hasPrecalledSnvVcf"
@@ -171,7 +226,7 @@ nextflow_function {
 
         when {
             params {
-                input         = "${projectDir}/subworkflows/local/utils_nfcore_raredisease_pipeline/tests/samplesheet_all_vcf.csv"
+                input         = "${projectDir}/subworkflows/local/utils_nfcore_raredisease_pipeline/tests/samplesheet_all_vcf_with_me.csv"
                 analysis_type = 'wgs'
             }
         }
@@ -225,7 +280,7 @@ nextflow_function {
             params {
                 input             = "${projectDir}/subworkflows/local/utils_nfcore_raredisease_pipeline/tests/samplesheet_partial_vcf.csv"
                 analysis_type     = 'wgs'
-                skip_subworkflows = 'mt_snv_calling'
+                skip_subworkflows = 'mt_snv_calling,me_calling'
             }
         }
 
@@ -241,6 +296,60 @@ nextflow_function {
         when {
             params {
                 input             = "${projectDir}/subworkflows/local/utils_nfcore_raredisease_pipeline/tests/samplesheet_partial_vcf.csv"
+                analysis_type     = 'wes'
+                run_mt_for_wes    = false
+            }
+        }
+
+        then {
+            assert function.success
+        }
+    }
+
+    test("validatePrecalledVcfCoverage - me uncovered and not skipped on wgs, errors") {
+
+        function "validatePrecalledVcfCoverage"
+
+        when {
+            params {
+                input             = "${projectDir}/subworkflows/local/utils_nfcore_raredisease_pipeline/tests/samplesheet_partial_vcf_no_me.csv"
+                analysis_type     = 'wgs'
+                skip_subworkflows = ''
+            }
+        }
+
+        then {
+            assertAll(
+                { assert function.failed },
+                { assert function.stdout.any { it.contains("me") } }
+            )
+        }
+    }
+
+    test("validatePrecalledVcfCoverage - me uncovered but explicitly skipped, no error") {
+
+        function "validatePrecalledVcfCoverage"
+
+        when {
+            params {
+                input             = "${projectDir}/subworkflows/local/utils_nfcore_raredisease_pipeline/tests/samplesheet_partial_vcf_no_me.csv"
+                analysis_type     = 'wgs'
+                skip_subworkflows = 'me_calling'
+            }
+        }
+
+        then {
+            assert function.success
+        }
+    }
+
+    test("validatePrecalledVcfCoverage - me not applicable on wes, no error") {
+
+        function "validatePrecalledVcfCoverage"
+
+        when {
+            params {
+                input             = "${projectDir}/subworkflows/local/utils_nfcore_raredisease_pipeline/tests/samplesheet_partial_vcf_no_me.csv"
                 analysis_type     = 'wes'
                 run_mt_for_wes    = false
             }

--- a/subworkflows/local/utils_nfcore_raredisease_pipeline/tests/samplesheet_all_vcf_with_me.csv
+++ b/subworkflows/local/utils_nfcore_raredisease_pipeline/tests/samplesheet_all_vcf_with_me.csv
@@ -1,0 +1,5 @@
+sample,vcf,tbi,type,case_id
+proband,/fake/proband_snv.vcf.gz,/fake/proband_snv.vcf.gz.tbi,snv,fam1
+proband,/fake/proband_sv.vcf.gz,/fake/proband_sv.vcf.gz.tbi,sv,fam1
+proband,/fake/proband_mt.vcf.gz,/fake/proband_mt.vcf.gz.tbi,mt,fam1
+proband,/fake/proband_me.vcf.gz,/fake/proband_me.vcf.gz.tbi,me,fam1

--- a/subworkflows/local/utils_nfcore_raredisease_pipeline/tests/samplesheet_partial_vcf_no_me.csv
+++ b/subworkflows/local/utils_nfcore_raredisease_pipeline/tests/samplesheet_partial_vcf_no_me.csv
@@ -1,0 +1,4 @@
+sample,vcf,tbi,type,case_id
+proband,/fake/proband_snv.vcf.gz,/fake/proband_snv.vcf.gz.tbi,snv,fam1
+proband,/fake/proband_sv.vcf.gz,/fake/proband_sv.vcf.gz.tbi,sv,fam1
+proband,/fake/proband_mt.vcf.gz,/fake/proband_mt.vcf.gz.tbi,mt,fam1

--- a/tests/test_vcf.nf.test
+++ b/tests/test_vcf.nf.test
@@ -28,6 +28,7 @@ nextflow_pipeline {
                 { assert !versions_yml.contains("TIDDIT_SV") },
                 { assert !versions_yml.contains("CNVNATOR_CALL") },
                 { assert !versions_yml.contains("GATK4_MUTECT2_MT") },
+                { assert !versions_yml.contains("RETROSEQ") },
                 // GENS/germlinecnvcaller are already moot here without any --skip_tools override:
                 // GENS is gated on !skip_snv_calling, and germlinecnvcaller only affects SV-caller
                 // priority inside CALL_STRUCTURAL_VARIANTS, which is skipped entirely
@@ -36,6 +37,7 @@ nextflow_pipeline {
                 { assert versions_yml.contains("ENSEMBLVEP_SNV") },
                 { assert versions_yml.contains("ENSEMBLVEP_SV") },
                 { assert versions_yml.contains("ENSEMBLVEP_MT") },
+                { assert versions_yml.contains("ENSEMBLVEP_ME") },
                 { assert versions_yml.contains("GENMOD_SCORE") },
                 { assert snapshot(
                     // Number of successful tasks
@@ -55,8 +57,12 @@ nextflow_pipeline {
 
         when {
             params {
-                outdir = "$outputDir"
-                input  = 'https://raw.githubusercontent.com/nf-core/test-datasets/raredisease/testdata/samplesheet_vcf_mixed_invalid.csv'
+                outdir            = "$outputDir"
+                input             = 'https://raw.githubusercontent.com/nf-core/test-datasets/raredisease/testdata/samplesheet_vcf_mixed_invalid.csv'
+                // This fixture predates the `me` type and has no me row; skip it explicitly so
+                // this test still isolates the mixed-input error rather than tripping the
+                // separate "missing me coverage" validation first.
+                skip_subworkflows = 'me_calling'
             }
         }
 

--- a/tests/test_vcf.nf.test.snap
+++ b/tests/test_vcf.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test_vcf": {
         "content": [
-            103,
+            121,
             {
                 "BCFTOOLS_CONCAT": {
                     "bcftools": 1.22
@@ -13,6 +13,9 @@
                     "bcftools": 1.22
                 },
                 "BCFTOOLS_VIEW": {
+                    "bcftools": 1.22
+                },
+                "BCFTOOLS_VIEW_FILTER": {
                     "bcftools": 1.22
                 },
                 "BCFTOOLS_VIEW_RHOCALL": {
@@ -50,6 +53,11 @@
                 "CUSTOM_ADDMOSTSEVEREPLI": {
                     "addmostseverepli": "1.2.0",
                     "bgzip": 1.21
+                },
+                "ENSEMBLVEP_ME": {
+                    "ensemblvep": 110.1,
+                    "perl-math-cdf": 0.1,
+                    "tabix": 1.21
                 },
                 "ENSEMBLVEP_MT": {
                     "ensemblvep": 110.1,
@@ -136,6 +144,9 @@
                 "TABIX_GNOMAD_AF": {
                     "tabix": 1.21
                 },
+                "TABIX_TABIX": {
+                    "tabix": 1.21
+                },
                 "UCSC_WIGTOBIGWIG": {
                     "ucsc": 482
                 },
@@ -157,6 +168,11 @@
                 }
             },
             [
+                "annotate_mobile_elements",
+                "annotate_mobile_elements/justhusky_me_pli_clinical.vcf.gz",
+                "annotate_mobile_elements/justhusky_me_pli_clinical.vcf.gz.tbi",
+                "annotate_mobile_elements/justhusky_me_pli_research.vcf.gz",
+                "annotate_mobile_elements/justhusky_me_pli_research.vcf.gz.tbi",
                 "annotate_snv",
                 "annotate_snv/genome",
                 "annotate_snv/genome/hugelymodelbat_rhocallviz",
@@ -233,7 +249,7 @@
                 "rank_and_filter/justhusky_sv_ranked_research.vcf.gz.tbi"
             ]
         ],
-        "timestamp": "2026-07-17T15:55:39.417216514",
+        "timestamp": "2026-08-04T13:58:44.360185287",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/workflows/raredisease.nf
+++ b/workflows/raredisease.nf
@@ -193,6 +193,7 @@ workflow RAREDISEASE {
     val_exclude_alt
     val_extract_alignments
     val_genome
+    val_has_precalled_me
     val_has_precalled_mt
     val_has_precalled_snv
     val_has_precalled_sv
@@ -338,11 +339,19 @@ workflow RAREDISEASE {
         .filter { _case_info, precalled -> precalled.mt }
         .map { case_info, precalled -> [case_info, precalled.mt[0], precalled.mt[1]] }
 
+    ch_precalled_me_vcf = ch_case_info_precalled
+        .filter { _case_info, precalled -> precalled.me }
+        .map { case_info, precalled -> [case_info, precalled.me[0]] }
+
+    ch_precalled_me_tbi = ch_case_info_precalled
+        .filter { _case_info, precalled -> precalled.me }
+        .map { case_info, precalled -> [case_info, precalled.me[1]] }
+
     // A case with any precalled VCF has zero fastq/bam/cram rows (enforced by validateNoMixedCaseInput),
     // so no alignment data exists at all for it - used to gate BAM-only auxiliary steps that have no
     // precalled substitute (SMN copy number, contamination check, mobile elements/repeat expansion
     // calling from BAM, vcf2cytosure)
-    def has_any_precalled_vcf = val_has_precalled_snv || val_has_precalled_sv || val_has_precalled_mt
+    def has_any_precalled_vcf = val_has_precalled_snv || val_has_precalled_sv || val_has_precalled_mt || val_has_precalled_me
 
     //
     // Input QC (ch_reads will be empty if fastq input isn't provided so FASTQC won't run if input is not fastq)
@@ -881,37 +890,44 @@ workflow RAREDISEASE {
         )
         ch_call_mobile_elements_vcf = CALL_MOBILE_ELEMENTS.out.vcf
         ch_call_mobile_elements_tbi = CALL_MOBILE_ELEMENTS.out.tbi
+    } else if (skip_me_calling) {
+        ch_call_mobile_elements_vcf = ch_precalled_me_vcf
+        ch_call_mobile_elements_tbi = ch_precalled_me_tbi
+    }
 
-        if (!skip_me_annotation) {
-            ch_me_annotate = ANNOTATE_MOBILE_ELEMENTS(
-                ch_genome_dictionary,
-                ch_genome_fasta,
-                ch_me_svdb_resources,
-                CALL_MOBILE_ELEMENTS.out.vcf,
-                ch_vep_cache,
-                val_genome,
-                val_vep_cache_version,
-                ch_vep_extra_files
-            )
+    if (!skip_me_annotation && val_analysis_type.equals("wgs")) {
 
-            FILTER_ANNOTATE_RANK_ME(
-                ch_hgnc_ids,
-                ch_pedfile,
-                ch_reduced_penetrance,
-                ch_score_config_sv,
-                ch_variant_consequences_sv,
-                ch_me_annotate.vcf_ann,
-                false,
-                true,
-                false,
-                false,
-                skip_generate_clinical_set,
-                ""
-            )
-            ch_ann_csq_pli_me_vcf_ann = FILTER_ANNOTATE_RANK_ME.out.vcf
-            ch_ann_csq_pli_me_tbi     = FILTER_ANNOTATE_RANK_ME.out.tbi
-
+        if (skip_me_calling && !val_has_precalled_me) {
+            log.warn("ME annotation is enabled but ME calling is skipped and no precalled VCF is available yet - no mobile elements will be annotated.")
         }
+
+        ch_me_annotate = ANNOTATE_MOBILE_ELEMENTS(
+            ch_genome_dictionary,
+            ch_genome_fasta,
+            ch_me_svdb_resources,
+            ch_call_mobile_elements_vcf,
+            ch_vep_cache,
+            val_genome,
+            val_vep_cache_version,
+            ch_vep_extra_files
+        )
+
+        FILTER_ANNOTATE_RANK_ME(
+            ch_hgnc_ids,
+            ch_pedfile,
+            ch_reduced_penetrance,
+            ch_score_config_sv,
+            ch_variant_consequences_sv,
+            ch_me_annotate.vcf_ann,
+            false,
+            true,
+            false,
+            false,
+            skip_generate_clinical_set,
+            ""
+        )
+        ch_ann_csq_pli_me_vcf_ann = FILTER_ANNOTATE_RANK_ME.out.vcf
+        ch_ann_csq_pli_me_tbi     = FILTER_ANNOTATE_RANK_ME.out.tbi
     }
 
 /*


### PR DESCRIPTION
<!--
# nf-core/raredisease pull request

Many thanks for contributing to nf-core/raredisease!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
-->

## Summary

This PR adds `me` as a fourth precalled-VCF type alongside `snv`/`sv`/`mt`: a samplesheet row with `type: me` now auto-skips `CALL_MOBILE_ELEMENTS` and feeds the supplied VCF straight into `ANNOTATE_MOBILE_ELEMENTS`

Continues [issue #261](https://github.com/nf-core/raredisease/issues/261).

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/raredisease/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/raredisease _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test_singleton,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
