### PR TITLE
Add `manifest.diagram` to `nextflow.config`

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -496,6 +496,7 @@ manifest {
     nextflowVersion = '!>=25.10.4'
     version         = '3.2.0dev'
     doi             = '10.5281/zenodo.7995798'
+    diagram         = 'docs/images/raredisease_metromap_light.png'
 }
 
 // Load DSL2 module options from config files, where each file contains the options for modules used in the eponymous subworkflow.


### PR DESCRIPTION
Adds the new `manifest.diagram` config attribute, pointing at the pipeline overview diagram.

See nf-core/tools#4460 for background: `manifest.diagram` gives a canonical location for the metro map, so that downstream consumers can find it. We'll use it for the nf-core website soon, for example. The new config option won't be released until Nextflow `26.10`, but older versions ignore unknown manifest fields, so it's safe to set in any pipeline today.